### PR TITLE
Add initial support for semicolons

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -204,5 +204,6 @@
 (annotation (arguments "(" @prepend_antispace))
 (function_definition (annotations (annotation) @append_hardline))
 
-; For now we remove semicolons and not handle them
-(";") @delete
+; This is used to preserve new lines after semicolons for people who use them on
+; all code lines
+(";") @append_input_softline

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -73,6 +73,9 @@ fn preprocess(content: &str) -> String {
 /// to clean up/balance out the output.
 fn postprocess(mut content: String) -> String {
     content = clean_up_lines_with_only_whitespace(content);
+    if content.contains(';') {
+        content = fix_dangling_semicolons(content);
+    }
 
     content
 }
@@ -106,6 +109,26 @@ fn clean_up_lines_with_only_whitespace(mut content: String) -> String {
         .build()
         .expect("empty line regex should compile");
     content = re.replace_all(&content, "\n").to_string();
+
+    content
+}
+
+/// This function fixes semicolons that end up on their own line with indentation
+/// by moving them to the end of the previous line.
+fn fix_dangling_semicolons(mut content: String) -> String {
+    // First, handle semicolons at the beginning of lines (move to end of previous line)
+    let re_leading = RegexBuilder::new(r"\n(\s*);(\s*)")
+        .multi_line(true)
+        .build()
+        .expect("leading semicolon regex should compile");
+    content = re_leading.replace_all(&content, ";$2").to_string();
+
+    // Then, handle trailing whitespace before semicolons at end of lines
+    let re_trailing = RegexBuilder::new(r"\s+;$")
+        .multi_line(true)
+        .build()
+        .expect("semicolon regex should compile");
+    content = re_trailing.replace_all(&content, ";").to_string();
 
     content
 }

--- a/tests/expected/semicolon.gd
+++ b/tests/expected/semicolon.gd
@@ -1,7 +1,15 @@
-var a = 10
-var b = ";"
+var a = 10;
+var b = "  ; ";
 
 
 func foo():
-	print(123)
-	pass
+	print(123);
+	pass;
+
+
+func bar():
+	var c = 2; var d = 3;
+	if c < d:
+		print("c is less than d");
+	if c > d:
+		print("a is greater than b");

--- a/tests/input/semicolon.gd
+++ b/tests/input/semicolon.gd
@@ -1,5 +1,15 @@
 var a = 10;
-var b = ";";
+var b = "  ; ";
+
+
 func foo():
 	print(123);
 	pass;
+
+
+func bar():
+	var c = 2; var d = 3;
+	if c < d:
+		print("c is less than d");
+	if c > d:
+		print("a is greater than b");


### PR DESCRIPTION
This PR aims to close #7 

It needs testing from people/on code from people who actively use semicolons in their code because I don't know how many edge cases there can be (I never used them myself).

This change preserves all the semicolons in this test case (it doesn't change any of the code):

```gdscript
var a = 10;
var b = "  ; ";


func foo():
	print(123);
	pass;


func bar():
	var c = 2; var d = 3;
	if c < d:
		print("c is less than d");
	if c > d:
		print("a is greater than b");
```

It also preserves the code presented in #7 (with the semicolons)