### PR TITLE
Add support for multiline function calls (close #19)

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -38,10 +38,20 @@
 ; FUNCTIONS
 (function_definition (name) @append_antispace)
 (function_definition (body) @prepend_hardline)
-(arguments "," @append_space)
 "->" @prepend_space @append_space
-(parameters "," @append_space)
-; MULTI-LINE PARAMETERS
+(arguments "," @append_space (#single_line_only!))
+(parameters "," @append_space (#single_line_only!))
+
+; MULTI-LINE ARGUMENTS (in function calls)
+(arguments "," @append_hardline (#multi_line_only!))
+; uncomment for double indentation in multiline function calls
+; (arguments (_) @prepend_indent_start @append_indent_end)
+(arguments
+    "(" @append_hardline @append_indent_start
+    ")" @prepend_hardline @prepend_indent_end
+    (#multi_line_only!))
+
+; MULTI-LINE PARAMETERS (in function definitions)
 (parameters
     "(" @append_hardline @append_indent_start
     ")" @prepend_hardline @prepend_indent_end


### PR DESCRIPTION
This PR adds support for multiline function calls described in #19.
About double indentation: we can add a cli flag for that, for function arguments and parameters. 
We can add one flag for function arguments (in calls) and one for function parameters (in definition). 
Double indentation achieved by just two topiary queries. We can place these two queries in separate `gdscript-double-indent-[arguments/parameters].scm` files and when flag is set concatenate `gdscript.scm` with these files before running topiary.