### PR TITLE
Add tree postprocessing (close #17)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "tempfile",
  "test_each_file",
  "topiary-core",
+ "tree-sitter",
  "tree-sitter-gdscript",
 ]
 
@@ -856,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.8"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7b8994f367f16e6fa14b5aebbcb350de5d7cbea82dc5b00ae997dd71680dd2"
+checksum = "ccd2a058a86cfece0bf96f7cce1021efef9c8ed0e892ab74639173e5ed7a34fa"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.0", features = ["derive"] }
 topiary-core = "0.6"
 tree-sitter-gdscript  = { git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git", rev = "d28f24a9cc482a5274d77d41918b052e72cc18f4" }
 regex = "1.11"
-
+tree-sitter = "0.25.9"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -68,17 +68,6 @@
     (#delimiter! "\n"))
 (extends_statement) @prepend_space
 
-; EMPTY LINES BETWEEN DEFINITIONS
-;
-; Add 2 newlines between top-level property definitions and function definitions
-; Note: the . between nodes constrains the query to direct siblings (instead of
-; matching a series of indirect siblings like e.g. variable + class + ... +
-; function)
-([(variable_statement) (function_definition) (class_definition) (signal_statement) (const_statement) (enum_definition) (constructor_definition)]
-    .
-    [(function_definition) (constructor_definition) (class_definition)] @prepend_delimiter @prepend_hardline
-    (#delimiter! "\n"))
-
 ; CONST DEFINITIONS
 (const_statement ":" @append_space)
 

--- a/tests/expected/func_multiline_calls.gd
+++ b/tests/expected/func_multiline_calls.gd
@@ -1,0 +1,26 @@
+func test():
+	print(
+		"Testing",
+		"multiline",
+		"print"
+	)
+
+	print(
+		"Testing",
+		"multiline",
+		"print"
+	)
+
+	print("Testing", "multiline", "print")
+
+	print(
+		"Testing",
+		"multiline",
+		"print"
+	)
+
+	print(
+		"Testing",
+		"multiline",
+		"print"
+	)

--- a/tests/expected/two_lines_spacing_with_comments.gd
+++ b/tests/expected/two_lines_spacing_with_comments.gd
@@ -1,0 +1,59 @@
+var a
+
+
+# case 1
+func test2() -> void:
+	pass
+
+var a # case 2
+
+
+func test2() -> void:
+	pass
+
+var a
+
+
+func test2() -> void:
+	pass
+
+const a = 10
+
+
+func test2() -> void:
+	pass
+
+
+class CheckSameCasesInsideNestedClass:
+	var a
+
+
+	# case 1
+	func test2() -> void:
+		pass
+
+	var a # case 2
+
+
+	func test2() -> void:
+		pass
+
+	var a
+
+
+	func test2() -> void:
+		pass
+
+	const a = 10
+
+
+	func test2() -> void:
+		pass
+
+
+	class DoubleNestedCaseWithInlineComments:
+		var a # case 2
+
+
+		func test2() -> void:
+			pass

--- a/tests/input/func_multiline_calls.gd
+++ b/tests/input/func_multiline_calls.gd
@@ -1,0 +1,17 @@
+func test():
+	print(
+		"Testing", "multiline",
+		"print"
+	)
+
+	print("Testing", "multiline", "print"
+		)
+
+	print("Testing", "multiline", "print")
+
+	print(
+		"Testing", "multiline", "print"
+		)
+
+	print(
+		"Testing", "multiline", "print")

--- a/tests/input/two_lines_spacing_with_comments.gd
+++ b/tests/input/two_lines_spacing_with_comments.gd
@@ -1,0 +1,48 @@
+var a
+
+# case 1
+func test2() -> void:
+	pass
+
+var a # case 2
+
+func test2() -> void:
+	pass
+
+var a
+
+func test2() -> void:
+	pass
+
+const a = 10
+
+func test2() -> void:
+	pass
+
+class CheckSameCasesInsideNestedClass:
+	var a
+
+	# case 1
+	func test2() -> void:
+		pass
+
+	var a # case 2
+
+	func test2() -> void:
+		pass
+
+	var a
+
+	func test2() -> void:
+		pass
+
+	const a = 10
+
+	func test2() -> void:
+		pass
+	
+	class DoubleNestedCaseWithInlineComments:
+		var a # case 2
+
+		func test2() -> void:
+			pass


### PR DESCRIPTION
This PR adds a tree-sitter based postprocessing, closing #17.

I forgot to commit tests for yesterday PR, so I added them here.

As I mentioned in #17, updating tree-sitter to 0.25.9 resulted in 33% performance improvement and I believe this is thanks to this [fix](https://github.com/tree-sitter/tree-sitter/pull/4614).